### PR TITLE
Potential typo in cost aggregation step

### DIFF
--- a/sgm.cpp
+++ b/sgm.cpp
@@ -303,7 +303,7 @@ void disprange_aggregation(int disparityRange,unsigned long ***C, unsigned int *
             for(int pdisp=0;pdisp<disparityRange;pdisp++)
             {
 
-                if((A[current_path][curx][cury-direction_y][pdisp]+LARGE_PENALTY)<term_1)
+                if((A[current_path][curx-direction_x][cury-direction_y][pdisp]+LARGE_PENALTY)<term_1)
                     term_1=A[current_path][curx- direction_x][cury-direction_y][pdisp]+LARGE_PENALTY;
             }
             A[current_path][curx][cury][d]=C[curx][cury][d]+min(term_1,term_2)-last_aggregated_k;


### PR DESCRIPTION
Hello, could this be a potential typo? When it tried to compute the lowest cost of the previous pixel along the direction. However, my local test gave me a worse disparity map with the fix than without it. So I am wondering if you implement it like this on purpose. 